### PR TITLE
새로운 모노크롬 아이콘이 배포될 때 안드로이드 모노크롬 저장소에 PR을 자동 생성할 수 있도록 깃헙 액션 추가

### DIFF
--- a/.github/workflows/monochrome-icon-dispatch.yml
+++ b/.github/workflows/monochrome-icon-dispatch.yml
@@ -1,0 +1,19 @@
+name: Dispatch monochrome icons when a new release is published
+
+on:
+  release:
+    types: [ published ]
+
+jobs:
+  dispatch:
+    name: Send create_pr event to android repo
+    runs-on: macos-latest
+    steps:
+      - name: Send event
+        shell: bash
+        run: |
+          curl -X POST \
+          -H "Accept: application/vnd.github.v3+json" \
+          -H "Authorization: token ${{ secrets.ANDROID_WORKFLOW_TOKEN }}" \
+          --data '{"event_type": "create_pr"}' \
+          https://api.github.com/repos/daangn/karrotx/dispatches


### PR DESCRIPTION
#### 변경사항
 * 모노크롬 아이콘을 안드로이드 [karrotx/design-foundation ](https://github.com/daangn/karrotx/tree/develop/design-foundation) 저장소로 싱크 시키기 위한 PR 생성 대한 트리거 액션을 추가했어요. 
 * 기존에는 깃헙 액션을 수동 & 크론 잡으로 돌리고 있었는데 깃헙 액션의 `repository_dispatch` 이벤트를 이용해서 karrot-ui-icon 저장소와의 싱크를 더 잘할 수 있게 개선했어요. 
 * 새로운 Release가 생성되면 https://github.com/daangn/karrotx/pull/93 과 같은 형태로 PR이 생성돼요~ 
 * @magi82 iOS 깃헙 PAT 토큰도 저장소 설정에 추가해주시면 iOS 쪽도 자동 트리거 될 수 있게 개선해둘게요. 연휴 끝나고 알려줘요 🙂